### PR TITLE
Changed $http.get.success() to $http.get().then()

### DIFF
--- a/command_center_node/public/index.html
+++ b/command_center_node/public/index.html
@@ -112,14 +112,19 @@
                     $http.post('/api/command/', {command: value});    
                 };
             
-                $http.get('/api/alerts').success(function(data) {
+                $http.get('/api/alerts').then(function(response) {
+
+                    var data = response.data;
+
                     $scope.latest_alerts = data.reverse(); 
                 });
             
-                $http.get('/api/temperatures').success(function(result) {
+                $http.get('/api/temperatures').then(function(response) {
+
+                    var data = response.data;
                     
-                    if(result.length > 0) {
-                        angular.forEach(result, function(x) {
+                    if(data.length > 0) {
+                        angular.forEach(data, function(x) {
 
                             var utcSeconds = x.eventtime._;
                             var d = new Date(0);


### PR DESCRIPTION
The $http legacy promise methods success and error have been deprecated
and will be removed in v1.6.0. Use the standard then method instead. If
$httpProvider.useLegacyPromiseExtensions is set to false then these
methods will throw $http/legacy error.

See:

https://code.angularjs.org/1.5.10/docs/api/ng/service/$http#deprecation-notice